### PR TITLE
use correct returntype on CloudFront::purge

### DIFF
--- a/src/Proxy/CloudFront.php
+++ b/src/Proxy/CloudFront.php
@@ -40,7 +40,7 @@ final class CloudFront implements ProxyClient, PurgeCapable
     /**
      * @param array<string, string> $headers
      */
-    public function purge($url, array $headers = []): self
+    public function purge($url, array $headers = []): static
     {
         $this->items[$url] = true;
 


### PR DESCRIPTION
FOSHttpCache 3 adds return types. 

if we would use the `self` return type on the interface, this would only declare that it returns an instance of the interface. `static` means its the exact class.

php explodes when it sees an extending class use `self`, so we should use `static` here. (although this being a final class, it happens to have the exact same semantics i think)

would be great if we can tag this as 1.1.1