### PR TITLE
chore: update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,8 @@
     },
     "require": {
         "php": "^8.1",
-        "async-aws/cloud-front": "^0.1.3",
-        "friendsofsymfony/http-cache": "^2.15 || ^3.0",
-        "nyholm/psr7": "^1.8"
+        "async-aws/cloud-front": "^0.1.3 || ^1.0",
+        "friendsofsymfony/http-cache": "^2.15 || ^3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.14",


### PR DESCRIPTION
Allows to use first stable version of [async-aws/cloud-front](https://github.com/async-aws/cloud-front/blob/1.0.1/CHANGELOG.md)